### PR TITLE
gaspi_run: fix: make TMP_MFILE and UNIQ_MFILE unique

### DIFF
--- a/bin/gaspi_run
+++ b/bin/gaspi_run
@@ -26,8 +26,9 @@ TYP=GASPI_MASTER
 MAX_NUMA_NODES=1
 HAS_NUMA=0
 HN=`/bin/hostname`
-TMP_MFILE=".gaspi_tmp"`date +%N`
-UNIQ_MFILE=".gaspi_tmp_uniq"`date +%N`
+TMP_PATTERN=".gpi2.XXXXXXXX"
+TMP_MFILE=$(TMPDIR=. mktemp ${TMP_PATTERN})
+UNIQ_MFILE=$(TMPDIR=. mktemp ${TMP_PATTERN})
 ORIG_MFILE=""
 NNODES=0
 DEBUG=0


### PR DESCRIPTION
fix: make TMP_MFILE and UNIQ_MFILE really unique (and allow to start more than one jobs within one second)
