### PR TITLE
gaspi_cleanup: fix: wait for ssh sessions

### DIFF
--- a/bin/gaspi_cleanup
+++ b/bin/gaspi_cleanup
@@ -52,7 +52,8 @@ kill_procs()
     for i in $hlist                                                                                             
     do                                                                                                          
         ssh $i killall -s KILL $PRG > /dev/null 2>&1 &
-    done                                                                                                        
+    done             
+    wait
 }
 
 #at least we need machinefile


### PR DESCRIPTION
Without the wait you are in trouble when doing loops like:

for p in param1 param2...; do gaspi_run ... $p; done

The processes started by subsequent runs are killed by the earlier forked cleanups.
