### PR TITLE
Use compiler environment variables.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 DOXYGEN:=$(shell which doxygen)
-GFORTRAN:=$(shell which gfortran)
+GFORTRAN:=$(shell which $FC)
 
 all: gpi fortran tests
 

--- a/README
+++ b/README
@@ -46,6 +46,15 @@ For example,
 
 installs GPI-2 under /prog/GPI2 instead of under the default location.
 
+Compiler selection
+------------------
+
+Using CC, CXX and FC, the compiler can be set for building GPI-2.
+For example,
+   CC=icc CXX=icpc FC=ifort ./install.sh -p /prog/GPI2
+
+Default is the GNU complier suite: CC=gcc, CXX=g++ and FC=gfortran.
+
 Infiniband support (default)
 ----------------------------
 

--- a/install.sh
+++ b/install.sh
@@ -66,9 +66,17 @@ clean_bak_files()
     fi
 }
 
+check_compilers()
+{
+  CC=${CC:-gcc}
+  CXX=${CXX:-g++}
+  FC=${FC:-gfortran}
+}
+
 #check some requirements
 check_util_exists gawk
 check_util_exists sed
+check_compilers
 
 while getopts ":hp:-:" opt; do
     case $opt in
@@ -195,7 +203,6 @@ cp src/make.inc src/make.inc.bak
 cp tests/make.defines tests/make.defines.bak
 
 echo "$0 $@" >> install.log
-gcc --version >> install.log
 
 if [ $GPI2_DEVICE = IB ]; then
 #check ofed installation
@@ -404,7 +411,7 @@ echo " done."
 
 
 printf "\nBuilding tests..."
-make -j$NCORES tests >> install.log 2>&1
+make -j$NCORES V=3 tests >> install.log 2>&1
 if [ $? != 0 ]; then
     echo "Compilation of tests failed (see install.log)"
     echo "Aborting..."

--- a/src/Makefile
+++ b/src/Makefile
@@ -79,7 +79,7 @@ $(OBJ_FORTRAN): GASPI.f90
 	echo "Fortran compiler (gfortran) not found!" ;\
 	false; \
 	fi;
-	$(FORTRANC) -O2 -I. -c $<  GASPI_Ext.f90 
+	$(FC) -O2 -I. -c $<  GASPI_Ext.f90 
 	cp gaspi.mod gaspi_types.mod gaspi_ext.mod ../include;
 
 mic: $(OBJS_MIC) $(OBJS_DBG_MIC)

--- a/src/make.inc
+++ b/src/make.inc
@@ -1,8 +1,6 @@
 OFED_PATH = /usr
 OFED_MIC_PATH = /opt/intel/mic/ofed/card/usr
-CC = gcc
-FORTRANC = gfortran
-HAS_FORTRAN:=$(shell which $(FORTRANC))
+HAS_FORTRAN:=$(shell which $(FC))
 GPI2_SRCDIR=$(CURDIR)
 
 CFLAGS += -Wall

--- a/tests/make.defines
+++ b/tests/make.defines
@@ -2,9 +2,6 @@ TOPROOT = $(PWD)
 
 GPI_DIR = $(TOPROOT)/..
 OFED_PATH = /usr
-CC = gcc
-CF = gfortran
-CXX = g++
 
 CFLAGS = -g -I$(GPI_DIR)/include
 CPPFLAGS = -g -I$(GPI_DIR)/include

--- a/tests/tests/fortran/Makefile
+++ b/tests/tests/fortran/Makefile
@@ -1,4 +1,4 @@
-F90CC:=$(shell which $(CF))
+F90CC:=$(shell which $(FC))
 
 BIN =  fortran_use.bin fortran_allreduces.bin fortran_seg_ptr.bin fortran_seg_use.bin
 
@@ -8,7 +8,7 @@ build: $(BIN)
 
 %.bin: %.f90
 	@if test "$(F90CC)" != ""; then \
-	$(CF) $(CFLAGS) $(LIB_PATH) -o $@ $^ $(LIBS); \
+	$(FC) $(CFLAGS) $(LIB_PATH) -o $@ $^ $(LIBS); \
 	fi	
 
 


### PR DESCRIPTION
Changed build infrastructure to use consistently the following common variables:
CC, CXX and FC. On default, they are set to the GNU compiler suite.

The compiler version check:
```gcc --version```
 was deleted because this is not working on Cray systems.