### PR TITLE
Fix weak symbol usage.

### DIFF
--- a/src/GPI2_SEG.c
+++ b/src/GPI2_SEG.c
@@ -128,7 +128,7 @@ pgaspi_segment_avail_local (gaspi_segment_id_t * const avail_seg_id)
   gaspi_verify_null_ptr(avail_seg_id);
 
   gaspi_number_t num_segs;
-  if( gaspi_segment_num (&num_segs) != GASPI_SUCCESS)
+  if( pgaspi_segment_num (&num_segs) != GASPI_SUCCESS)
     {
       return GASPI_ERROR;
     }
@@ -140,7 +140,7 @@ pgaspi_segment_avail_local (gaspi_segment_id_t * const avail_seg_id)
     }
 
   gaspi_number_t segs_max;
-  if( gaspi_segment_max (&segs_max) != GASPI_SUCCESS )
+  if( pgaspi_segment_max (&segs_max) != GASPI_SUCCESS )
     {
       return GASPI_ERROR;
     }
@@ -156,7 +156,7 @@ pgaspi_segment_avail_local (gaspi_segment_id_t * const avail_seg_id)
       return GASPI_ERR_MEMALLOC;
     }
 
-  if( gaspi_segment_list (num_segs, segment_ids) != GASPI_SUCCESS )
+  if( pgaspi_segment_list (num_segs, segment_ids) != GASPI_SUCCESS )
     {
       free(segment_ids);
       return GASPI_ERROR;


### PR DESCRIPTION
In ```pgaspi_segment_avail_local``` were called weak symbols e.g. ```gaspi_segment_num```. I just converted these calls to strong symbols. This is better for profiling/tracing tools.