### PR TITLE
Fix linking of MPI libraries.

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -40,6 +40,7 @@ endif
 if WITH_MPI
 lib_default_cflags += -DGPI2_WITH_MPI
 lib_default_cflags += @ac_inc_mpi@
+lib_default_cflags += @ac_lib_mpi@
 endif
 
 # INFINIBAND


### PR DESCRIPTION
Depending on the location of the MPI libraries, linking of the GPI-2
library fails due to missing/incorrect linker flags.