### PR TITLE
FIX: configure: LDFLAGS should come at the end

### DIFF
--- a/config/devices.m4
+++ b/config/devices.m4
@@ -130,14 +130,17 @@ return num_devices;
 _ACEOF
 
 	OLD_CFLAGS=$CFLAGS
-	CFLAGS="$AM_CFLAGS $CFLAGS -Wno-unused-variable -I$1 -L$2 -libverbs"
-	AS_IF($CC $CFLAGS conftest_ib.c -o conftest_ib.exe,
+	OLD_LDFLAGS=$LDFLAGS
+	CFLAGS="$AM_CFLAGS $CFLAGS -Wno-unused-variable -I$1"
+	LDFLAGS="$AM_LDFLAGS $LDFLAGS -L$2 -libverbs"
+	AS_IF($CC $CFLAGS conftest_ib.c -o conftest_ib.exe $LDFLAGS, 
 	  [AC_MSG_RESULT([yes]);
 	  $3],
 	  [AC_MSG_RESULT([no]);
 	  $4]
 	  )
 	CFLAGS=$OLD_CFLAGS
+	LDFLAGS=$OLD_LDFLAGS
 	AC_LANG_POP([C])
 
 AC_MSG_CHECKING([whether there are actual IB devices])

--- a/tests/microbenchmarks/Makefile.am
+++ b/tests/microbenchmarks/Makefile.am
@@ -11,7 +11,7 @@ endif
 if WITH_MPI
 AM_CFLAGS += -DGPI2_WITH_MPI
 AM_CFLAGS += @ac_inc_mpi@
-LDFLAGS += @ac_lib_mpi@  @mpi_extra_flags@
+LDADD += @ac_lib_mpi@  @mpi_extra_flags@
 endif
 
 # MICROBENCHMARKS

--- a/tests/tests/Make.inc
+++ b/tests/tests/Make.inc
@@ -15,7 +15,7 @@ endif
 if WITH_MPI
 AM_CFLAGS += -DGPI2_WITH_MPI
 AM_CFLAGS += @ac_inc_mpi@
-LDFLAGS += @ac_lib_mpi@ @mpi_extra_flags@
+LDADD += @ac_lib_mpi@ @mpi_extra_flags@
 if WITH_FORTRAN
 AM_FCFLAGS += -DGPI2_WITH_MPI
 endif


### PR DESCRIPTION
This fixes the following error for me:

```
+ /home/vanderaa/local/spack/lib/spack/env/gcc/gcc -std=gnu99 -Wall -Wno-unused-variable -I/home/vanderaa/local/spack/opt/spack/linux-ubuntu20.04-westmere/gcc-9.3.0/rdm
a-core-34.0-xc7xzezjesw3qoslrmf53gx3xlscbnmb/include/infiniband -L/home/vanderaa/local/spack/opt/spack/linux-ubuntu20.04-westmere/gcc-9.3.0/rdma-core-34.0-xc7xzezjesw3q
oslrmf53gx3xlscbnmb/lib -libverbs conftest_ib.c -o conftest_ib.exe
/usr/bin/ld: /tmp/ccQm4Ss0.o: in function `main':
conftest_ib.c:(.text+0x2a): undefined reference to `ibv_get_device_list'
/usr/bin/ld: /tmp/ccQm4Ss0.o: in function `main':                                                                                                           [2998/11190]
conftest_ib.c:(.text+0x2a): undefined reference to `ibv_get_device_list'
/usr/bin/ld: conftest_ib.c:(.text+0x60): undefined reference to `ibv_free_device_list'
collect2: error: ld returned 1 exit status