### PR TITLE
Allow specifying an executable that is on the `PATH`

### DIFF
--- a/bin/gaspi_run
+++ b/bin/gaspi_run
@@ -183,9 +183,16 @@ while [ -n "$1" ]; do
             VALIDATE_MACHINEFILE=1
             ;;
         *) #Sucks! we're taking a small risk here
-            if [ -x $1 ]; then
+            # Try to see if it is an executable found on the PATH
+            FULLPATH=$(which "$1")
+            # If this did not turn up anything, try to convert the argumen to a full path
+            if [ -z "$FULLPATH" ]; then
+              FULLPATH=$(readlink -f "$1")
+            fi
+            # Finally, check if we find an executable file at the location
+            if [ -x "$FULLPATH" ]; then
 
-                PRG=$(readlink -f $1)
+                PRG="$FULLPATH"
                 shift
                 PRG_ARGS="$*"
                 break

--- a/bin/gaspi_run.ssh
+++ b/bin/gaspi_run.ssh
@@ -183,9 +183,16 @@ while [ -n "$1" ]; do
             VALIDATE_MACHINEFILE=1
             ;;
         *) #Sucks! we're taking a small risk here
-            if [ -x $1 ]; then
+            # Try to see if it is an executable found on the PATH
+            FULLPATH=$(which "$1")
+            # If this did not turn up anything, try to convert the argumen to a full path
+            if [ -z "$FULLPATH" ]; then
+              FULLPATH=$(readlink -f "$1")
+            fi
+            # Finally, check if we find an executable file at the location
+            if [ -x "$FULLPATH" ]; then
 
-                PRG=$(readlink -f $1)
+                PRG="$FULLPATH"
                 shift
                 PRG_ARGS="$*"
                 break


### PR DESCRIPTION
Before, using an executable name that can be found only on the `PATH` (i.e., neither a relative nor an absolute path to a concrete file) was not supported. This makes it (unnecessarily) hard to use system-installed executables such as `julia` or `python3`. With this PR, the script first queries `which <executable_name>` to see if it is an executable on the `PATH` and if not found, proceeds by treating the executable name as a relative or absolute path.

`next`:
```shell
$> gaspi_run -m machinefile hostname

Error: Cannot execute hostname (or file does not exist)
```

This PR:
```shell
$> gaspi_run -m machinefile hostname
pcm016
pcm016
pcm016
```

Machinefile:
```shell
yes hostname | head -n 3 > machinefile
```