### PR TITLE
Allow to start single-node runs without machinefile

### DIFF
--- a/bin/gaspi_run
+++ b/bin/gaspi_run
@@ -29,6 +29,7 @@ HN=$(hostname)
 TMP_PATTERN="/tmp/.gpi2.XXXXXXXX"
 TMP_MFILE=$(mktemp ${TMP_PATTERN})
 UNIQ_MFILE=$(mktemp ${TMP_PATTERN})
+AUTO_MFILE=$(mktemp ${TMP_PATTERN})
 ORIG_MFILE=""
 NNODES=0
 DEBUG=0
@@ -39,6 +40,7 @@ remove_temp_file()
 {
     rm -f $TMP_MFILE
     rm -f $UNIQ_MFILE
+    rm -f $AUTO_MFILE
 }
 
 #helper functions
@@ -199,6 +201,14 @@ done
 
 if [ -z "$PRG" ]; then
     print_error_exit "No binary file provided. See help (-h option)"
+fi
+
+if [ -z "$MFILE" ]; then
+  if [ $NNODES -eq 0 ]; then
+    print_error_exit "Number of procs must be non-zero if no machinefile is provided. See help (-n option)"
+  fi
+  yes $(hostname) | head -n $NNODES > "$AUTO_MFILE"
+  MFILE="$AUTO_MFILE"
 fi
 
 trap kill_procs TERM INT QUIT

--- a/bin/gaspi_run.ssh
+++ b/bin/gaspi_run.ssh
@@ -29,6 +29,7 @@ HN=$(hostname)
 TMP_PATTERN="/tmp/.gpi2.XXXXXXXX"
 TMP_MFILE=$(mktemp ${TMP_PATTERN})
 UNIQ_MFILE=$(mktemp ${TMP_PATTERN})
+AUTO_MFILE=$(mktemp ${TMP_PATTERN})
 ORIG_MFILE=""
 NNODES=0
 DEBUG=0
@@ -39,6 +40,7 @@ remove_temp_file()
 {
     rm -f $TMP_MFILE
     rm -f $UNIQ_MFILE
+    rm -f $AUTO_MFILE
 }
 
 #helper functions
@@ -199,6 +201,14 @@ done
 
 if [ -z "$PRG" ]; then
     print_error_exit "No binary file provided. See help (-h option)"
+fi
+
+if [ -z "$MFILE" ]; then
+  if [ $NNODES -eq 0 ]; then
+    print_error_exit "Number of procs must be non-zero if no machinefile is provided. See help (-n option)"
+  fi
+  yes $(hostname) | head -n $NNODES > "$AUTO_MFILE"
+  MFILE="$AUTO_MFILE"
 fi
 
 trap kill_procs TERM INT QUIT


### PR DESCRIPTION
It would be great if it were possible to use `gaspi_run` solely with the `-n N` option to run a GPI-2 program in parallel with `N` procs on the current node, that is, without having to create a machinefile first. This would mimic the behavior of `mpirun`/`mpiexec` which will also start multiple ranks on the current node if no machinefile is given (and no job scheduler environment is detected). Further, it makes it easier to quickly test a GASPI program with a different number of procs.

In the current `master`, starting `gaspi_run` solely with the `-n` option but without the `-m` option will cause the script to be stuck while waiting for input in `validate_machinefile`. With this PR, passing `-n N` without a machinefile will result in `gaspi_run` to create a temporary machinefile with the current node's hostname added `N` times. After a successful run, the auto-generated machinefile is deleted again.

This PR is partially an issue report, partially a proposed fix. If the general approach is deemed to be viable by the GPI-2 developers, I can also add some notes to the README and the usage string of `gaspi_run` to document the new behavior.